### PR TITLE
Stewie410 Rewrite

### DIFF
--- a/bash-folders-battery-hook.sh
+++ b/bash-folders-battery-hook.sh
@@ -24,7 +24,7 @@ EOF
 run() {
     set -e
 
-    local status capacity path
+    local status capacity
     status="$(< "/sys/class/power_supply/BAT${settings['battery']}/status")"
     capacity="$(< "/sys/class/power_supply/BAT${settings['battery']}/capacity")"
 

--- a/bash-folders-battery-hook.sh
+++ b/bash-folders-battery-hook.sh
@@ -72,6 +72,7 @@ main() {
             -h | --help )       usage; return 0;;
             -l | --low )        settings['low']="${2}"; shift;;
             -H | --high )       settings['high']="${2}"; shift;;
+            -b | --battery )    settings['battery']="${2}"; shift;;
             -- )                shift; break;;
             * )                 break;;
         esac

--- a/bash-folders-battery-hook.sh
+++ b/bash-folders-battery-hook.sh
@@ -84,6 +84,10 @@ main() {
     fi
 
     mkdir --parents "${1}"
+    for i in "charging" "discharging" "full" "low" "high"; do
+        touch -a "${1}/${j}"
+        chmod +x "${_}"
+    done
 
     run "${1}"
 }

--- a/bash-folders-battery-hook.sh
+++ b/bash-folders-battery-hook.sh
@@ -2,7 +2,7 @@
 
 usage() {
     cat << EOF
-USAGE: ${0##*/} [OPTION] PATH
+USAGE: ${0##*/} [OPTIONS] PATH
 
 Launches other scripts for different battery states
 

--- a/bash-folders-battery-hook.sh
+++ b/bash-folders-battery-hook.sh
@@ -92,11 +92,7 @@ main() {
             -l | --low )        settings['low']="${2}"; shift;;
             -H | --high )       settings['high']="${2}"; shift;;
             -- )                shift; break;;
-            * )
-                printf '%s\n' "Unknown option: '${1}'" >&2
-                usage
-                return 1
-                ;;
+            * )                 break;;
         esac
         shift
     done

--- a/bash-folders-battery-hook.sh
+++ b/bash-folders-battery-hook.sh
@@ -1,118 +1,96 @@
 #!/usr/bin/env bash
 
-# --
-# Description: Script that launches other scripts in different battery states.
-# --
-# Cron: * * * * *  bash-folders-battery-hook.sh --folder [folder path]
-# --
-
-# START
 set -e
 
-
-# FUNCTIONS
-
 usage() {
-    if [ "$*" != "" ] ; then
-        echo "Error: $*"
-    fi
+    [[ -n "${*}" ]] && printf '%s\n' "Error: ${*}" >&2
 
     cat << EOF
-Usage: $PROGNAME [OPTION]
-Script that launches other scripts in different battery states.
-  "discharging" When the battery is in use.
-  "charging" When the battery is charging.
-  "low" When it reaches the low percentage.
-  "high" When it reaches the high percentage.
-  "full" When the battery is full.
+USAGE: ${0##*/} [OPTION] --folder PATH
 
-Options:
---folder [path]  Folder where the different scripts are located.
---low [number]   Low battery percentage. Default 15.
---high [number]  High battery percentage. Default 85.
---help           Display this usage message and exit
+Launches other scripts in different battery states
+
+OPTIONS:
+    --help              Display this usage message and exit
+    --folder PATH       PATH where the different scripts are located
+    --low INT           Low battery percentage (default: 15)
+    --high INT          High battery percentage (default: 85)
+
+STATES:
+    discharching        When the battery is in use
+    charging            When the battery is charging
+    low                 When the battery reaches the low percentage
+    high                When the battery reaches the high percentag
+    full                When the battery is full
 EOF
 
     exit 1
 }
 
 status() {
-    # Possible values: Discharging, Charging and Full
     cat /sys/class/power_supply/BAT0/status
 }
 
 capacity() {
-    # Possible values: 0-100
     cat /sys/class/power_supply/BAT0/capacity
 }
 
 run_discharging() {
-    # Check if discharging script exists
-    if [ ! -f "$PATH_DISCHARGING_SCRIPT" ]; then
-	# If not, create it
-	touch "$PATH_DISCHARGING_SCRIPT"
-	chmod +x "$PATH_DISCHARGING_SCRIPT"
+    if ! [[  -f "$PATH_DISCHARGING_SCRIPT" ]]; then
+        touch "$PATH_DISCHARGING_SCRIPT"
+        chmod +x "$PATH_DISCHARGING_SCRIPT"
     fi
-    # If status is discharging, run discharging script
-    if [ "$(status)" = "Discharging" ]; then
-	$PATH_DISCHARGING_SCRIPT
+
+    if [[ "$(status)" == "Discharging" ]]; then
+        $PATH_DISCHARGING_SCRIPT
     fi
 }
 
 run_charging() {
-    # Check if charging script exists
-    if [ ! -f "$PATH_CHARGING_SCRIPT" ]; then
-	# If not, create it
-	touch "$PATH_CHARGING_SCRIPT"
-	chmod +x "$PATH_CHARGING_SCRIPT"
+    if ! [[ -f "$PATH_CHARGING_SCRIPT" ]]; then
+        touch "$PATH_CHARGING_SCRIPT"
+        chmod +x "$PATH_CHARGING_SCRIPT"
     fi
-    # If status is charging, run charging script
-    if [ "$(status)" = "Charging" ]; then
-	$PATH_CHARGING_SCRIPT
+
+    if [[ "$(status)" == "Charging" ]]; then
+        $PATH_CHARGING_SCRIPT
     fi
 }
 
 run_low() {
-    # Check if low script exists
-    if [ ! -f "$PATH_LOW_SCRIPT" ]; then
-	# If not, create it
-	touch "$PATH_LOW_SCRIPT"
-	chmod +x "$PATH_LOW_SCRIPT"
+    if ! [[ -f "$PATH_LOW_SCRIPT" ]]; then
+        touch "$PATH_LOW_SCRIPT"
+        chmod +x "$PATH_LOW_SCRIPT"
     fi
-    # If status is discharging and battery is low, run low script
-    if [ "$(status)" = "Discharging" ] && [ "$(capacity)" -le "$LOW_BATTERY" ]; then
-	$PATH_LOW_SCRIPT
+
+    if [[ "$(status)" == "Discharging" ]] && [[ "$(capacity)" -le "$LOW_BATTERY" ]]; then
+        $PATH_LOW_SCRIPT
     fi
 }
 
 run_high() {
-    # Check if high script exists
-    if [ ! -f "$PATH_HIGH_SCRIPT" ]; then
-	# If not, create it
-	touch "$PATH_HIGH_SCRIPT"
-	chmod +x "$PATH_HIGH_SCRIPT"
+    if ! [[ -f "$PATH_HIGH_SCRIPT" ]]; then
+        touch "$PATH_HIGH_SCRIPT"
+        chmod +x "$PATH_HIGH_SCRIPT"
     fi
-    # If status is charging and battery is high, run high script
-    if [ "$(status)" = "Charging" ] && [ "$(capacity)" -ge "$HIGH_BATTERY" ]; then
-	$PATH_HIGH_SCRIPT
+
+    if [[ "$(status)" == "Charging" ]] && [[ "$(capacity)" -ge "$HIGH_BATTERY" ]]; then
+        $PATH_HIGH_SCRIPT
     fi
 }
 
 run_full() {
-    # Check if full script exists
-    if [ ! -f "$PATH_FULL_SCRIPT" ]; then
-	# If not, create it
-	touch "$PATH_FULL_SCRIPT"
-	chmod +x "$PATH_FULL_SCRIPT"
+    if ! [[ -f "$PATH_FULL_SCRIPT" ]]; then
+        touch "$PATH_FULL_SCRIPT"
+        chmod +x "$PATH_FULL_SCRIPT"
     fi
-    # If status is charging and battery is full, run full script
-    if [ "$(status)" = "Full" ]; then
-	$PATH_FULL_SCRIPT
+
+    if [[ "$(status)" = "Full" ]]; then
+        $PATH_FULL_SCRIPT
     fi
 }
 
 start() {
-    # Run all scripts
     run_discharging
     run_charging
     run_low
@@ -120,37 +98,26 @@ start() {
     run_full
 }
 
-# CONTROLE ARGUMENTS
-
-# Parse command line arguments
-while [[ $# -gt 0 ]]
-do
-    key="$1"
-    case $key in
-	--folder)
-	    FOLDER_ORIGIN="$2"
-	    shift # past argument
-	    shift # past value
-	    ;;
-	--low)
-	    LOW_BATTERY="$2"
-	    shift # past argument
-	    shift # past value
-	    ;;
-	--high)
-	    HIGH_BATTERY="$2"
-	    shift # past argument
-	    shift # past value
-	    ;;
-	*)
-	    usage "Unknown option: $1"
-	    ;;
+while [[ $# -gt 0 ]]; do
+    case "${1}" in
+    --folder)
+        FOLDER_ORIGIN="$2"
+        shift 2
+        ;;
+    --low)
+        LOW_BATTERY="$2"
+        shift 2
+        ;;
+    --high)
+        HIGH_BATTERY="$2"
+        shift 2
+        ;;
+    *)
+        usage "Unknown option: $1"
+        ;;
     esac
 done
 
-
-# VARIABLES
-PROGNAME=$(basename "$0")
 LOW_BATTERY=20
 HIGH_BATTERY=80
 DISCHARGING_SCRIPT="discharging"
@@ -164,9 +131,8 @@ PATH_HIGH_SCRIPT="$FOLDER_ORIGIN/$HIGH_SCRIPT"
 FULL_SCRIPT="full"
 PATH_FULL_SCRIPT="$FOLDER_ORIGIN/$FULL_SCRIPT"
 
-# Check if the required --folder flag is provided
-if [ -z "$FOLDER_ORIGIN" ]; then
-    echo "Error: The --folder flag is required."
+if [[ -z "$FOLDER_ORIGIN" ]]; then
+    printf '%s\n' "Error: The --folder flag is required" >&2
     exit 1
 else
     start

--- a/bash-folders-battery-hook.sh
+++ b/bash-folders-battery-hook.sh
@@ -10,7 +10,7 @@ OPTIONS:
     -h, --help          Display this usage message and exit
     -l, --low INT       Low battery percentage (default: ${defaults['low']})
     -h, --high INT      High battery percentage (default: ${defaults['high']})
-    -b, --battery INT   Battery to be checked
+    -b, --battery INT   Battery to be checked (default: ${defaults['battery']})
 
 STATE SCRIPTS:
     discharching        When the battery is in use

--- a/bash-folders-battery-hook.sh
+++ b/bash-folders-battery-hook.sh
@@ -12,7 +12,7 @@ OPTIONS:
     -h, --high INT      High battery percentage (default: ${defaults['high']})
     -b, --battery INT   Battery to be checked
 
-STATES:
+STATE SCRIPTS:
     discharching        When the battery is in use
     charging            When the battery is charging
     low                 When the battery reaches the low percentage
@@ -85,7 +85,7 @@ main() {
 
     mkdir --parents "${1}"
     for i in "charging" "discharging" "full" "low" "high"; do
-        touch -a "${1}/${j}"
+        touch -a "${1}/${i}"
         chmod +x "${_}"
     done
 

--- a/bash-folders-battery-hook.sh
+++ b/bash-folders-battery-hook.sh
@@ -21,25 +21,6 @@ STATES:
 EOF
 }
 
-start() {
-    local cap
-    cap="$(capacity)"
-
-    case "$(status | tr '[:upper:]' '[:lower:]')" in
-        full )
-            run_full
-            ;;
-        discharging )
-            run_discharging
-            (( cap <= settings['low'] )) && run_low
-            ;;
-        charging )
-            run_charging
-            (( cap >= settings['high'] )) && run_high
-            ;;
-    esac
-}
-
 run() {
     set -e
 

--- a/bash-folders-battery-hook.sh
+++ b/bash-folders-battery-hook.sh
@@ -91,6 +91,7 @@ main() {
             -h | --help )       usage; return 0;;
             -l | --low )        settings['low']="${2}"; shift;;
             -H | --high )       settings['high']="${2}"; shift;;
+            -- )                shift; break;;
             * )
                 printf '%s\n' "Unknown option: '${1}'" >&2
                 usage

--- a/bash-folders-image-to-webp.sh
+++ b/bash-folders-image-to-webp.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
-
 usage() {
     cat << EOF
 USAGE: ${0##*/} [OPTIONS] PATH
@@ -15,8 +13,6 @@ OPTIONS:
 SEE ALSO:
     cwebp(1), inotifywait(1)
 EOF
-
-    exit 1
 }
 
 require() {
@@ -27,6 +23,8 @@ require() {
 
 run() {
     local file extension
+
+    set -e
 
     mkdir --parents "${1}"
 

--- a/bash-folders-image-to-webp.sh
+++ b/bash-folders-image-to-webp.sh
@@ -56,11 +56,7 @@ main() {
             -h | --help )       usage; return 0;;
             -q | --quality )    quality="${2}"; shift;;
             -- )                shift; break;;
-            * )
-                printf '%s\n' "Unknown option: '${1}'" >&2
-                usage
-                return 1
-                ;;
+            * )                 break;;
         esac
         shift
     done

--- a/bash-folders-image-to-webp.sh
+++ b/bash-folders-image-to-webp.sh
@@ -1,98 +1,67 @@
 #!/usr/bin/env bash
 
-# --
-# Description: Script that watches when new image (PNG or JPEG) are added and transform to WebP format.
-# --
-# Requirements: Install webp
-# Example Debian: $sudo apt install webp
-# --
-# Cron: @reboot bash-folders-image-to-webp.sh >/dev/null 2>&1 &
-# --
-
-# START
 set -e
 
-
-# FUNCTIONS
-
 usage() {
-    if [ "$*" != "" ] ; then
-        echo "Error: $*"
-    fi
+    [[ -n "${*}" ]] && printf '%s\n' "Error: ${*}" >&2
 
     cat << EOF
-Usage: $PROGNAME [OPTION]
-Watches when new image (PNG or JPEG) are added and transform to WebP format.
-Options:
---folder [path]  Folder path where will be monitored.
---help           Display this usage message and exit
+USAGE: ${0##*/} [OPTION] --folder PATH
+
+Watches when new image (PNG or JPEG) are added and transform to WebP format
+
+OPTIONS:
+    --help              Display this usage message and exit
+    --folder PATH       PATH to be monitored
 EOF
 
     exit 1
 }
 
 start() {
-    # Monitors the selected folder
-    inotifywait -m -e create,moved_to --format '%f' "$FOLDER_ORIGIN" |
-	while read -r filename; do
-	    # Gets the file extension
-	    extension="${filename##*.}"
-	    # Checks if the extension is in the extension list
-	    for ext in "${EXTENSIONS_TO_WATCH[@]}"; do
-		if [[ "$ext" = "$extension" ]]; then
-		    filename_output="${filename%.*}.webp"
-		    # Displays a flat file of information
-		    touch "$FOLDER_ORIGIN/$MESSAGE_WAITING"
-		    # Converts the image to WebP
-		    cwebp -q "$QUALITY" "$FOLDER_ORIGIN/$filename" -o "$FOLDER_ORIGIN/$filename_output"
-		    # Remove a flat file of information
-		    rm "$FOLDER_ORIGIN/$MESSAGE_WAITING"
-		fi
-	    done
-	done
+    inotifywait -m -e create,moved_to --format '%f' "$FOLDER_ORIGIN" | while read -r filename; do
+        extension="${filename##*.}"
+        for ext in "${EXTENSIONS_TO_WATCH[@]}"; do
+            if [[ "$ext" == "$extension" ]]; then
+                filename_output="${filename%.*}.webp"
+                touch "$FOLDER_ORIGIN/$MESSAGE_WAITING"
+                cwebp -q "$QUALITY" "$FOLDER_ORIGIN/$filename" -o "$FOLDER_ORIGIN/$filename_output"
+                rm "$FOLDER_ORIGIN/$MESSAGE_WAITING"
+            fi
+        done
+    done
 }
 
-
-# CONTROLE ARGUMENTS
-
-# Parse command line arguments
 while [[ $# -gt 0 ]]
 do
     key="$1"
     case $key in
-	--folder)
-	    FOLDER_ORIGIN="$2"
-	    shift # past argument
-	    shift # past value
-	    ;;
-	--quality)
-	    QUALITY="$2"
-	    shift # past argument
-	    shift # past value
-	    ;;
-	*)
-	    usage "Unknown option: $1"
-	    ;;
+    --folder)
+        FOLDER_ORIGIN="$2"
+        shift 2
+        ;;
+    --quality)
+        QUALITY="$2"
+        shift 2
+        ;;
+    *)
+        usage "Unknown option: $1"
+        ;;
     esac
 done
 
-# VARIABLES
-PROGNAME=$(basename "$0")
 QUALITY="90"
 MESSAGE_WAITING="converting_please_wait"
 EXTENSIONS_TO_WATCH=("jpg" "jpeg" "png")
 
-# CHECKS
-
-# Check if exists cwebp
-if ! which cwebp > /dev/null; then
-    echo "Error: You must install the WebP terminal tools."
+if ! command -v cwebp > /dev/null; then
+	printf '%s\n' "Error: You must install WebP tooling" >&2
     exit 1
 fi
 
 # Check if the required --folder flag is provided
-if [ -z "$FOLDER_ORIGIN" ]; then
-    echo "Error: The --folder flag is required."
+if [[ -z "$FOLDER_ORIGIN" ]]; then
+	printf '%s\n' "Error: The --folder flag is required" >&2
     exit 1
 fi
 

--- a/bash-folders-image-to-webp.sh
+++ b/bash-folders-image-to-webp.sh
@@ -9,9 +9,6 @@ Watches when new image (PNG or JPEG) are added and transform to WebP format
 OPTIONS:
     -h, --help          Display this usage message and exit
     -q, --quaity INT    Specify the compression factor between 0-100 (default: 90)
-
-SEE ALSO:
-    cwebp(1), inotifywait(1)
 EOF
 }
 

--- a/bash-folders-image-to-webp.sh
+++ b/bash-folders-image-to-webp.sh
@@ -19,15 +19,14 @@ require() {
 }
 
 run() {
-    local file extension
+    local file
 
     set -e
 
     mkdir --parents "${1}"
 
     while read -r file; do
-        extension="${file##*.}"
-        [[ "${extension,,}" =~ ^(png|jpe?g)$ ]] || continue
+        [[ "${file,,}" =~ \.(png|jpe?g)$ ]] || continue
 
         printf '%s\n' "Converting file '${file}'..."
         if ! cwebp -q "${quality}" -o "${1}/${file%.*}.webp" "${1}/${file}"; then

--- a/bash-folders-video-optimizer.sh
+++ b/bash-folders-video-optimizer.sh
@@ -26,20 +26,17 @@ optimize() {
 }
 
 run() {
-    local file extension optimized
-    optimized="${1}/optimized"
+    local file
 
     set -e
 
-    mkdir --parents "${optimized}"
+    mkdir --parents "${1}/optimized"
 
     while read -r file; do
-        extension="${file##*.}"
-        [[ "${extension,,}" =~ (avi|m(kv|p4|ov)) ]] || continue
+        [[ "${file,,}" =~ \.(avi|m(kv|p4|ov))$ ]] || continue
 
         printf '%s\n' "Optimizing file '${file}'..."
-
-        if ! optimize "${file}" "${optimized}/${file%.*}.mp4"; then
+        if ! optimize "${file}" "${1}/optimized/${file%.*}.mp4"; then
             printf '%s\n' "Failed to optimize file: '${file}'" >&2
         fi
     done < <(inotifywait --monitor --event "create" --event "moved_to" --format '%f' "${1}")

--- a/bash-folders-video-optimizer.sh
+++ b/bash-folders-video-optimizer.sh
@@ -35,7 +35,7 @@ run() {
 
     while read -r file; do
         extension="${file##*.}"
-        [[ "${extension,,}" =~ foo ]] || continue
+        [[ "${extension,,}" =~ (avi|m(kv|p4|ov)) ]] || continue
 
         printf '%s\n' "Optimizing file '${file}'..."
 

--- a/bash-folders-video-optimizer.sh
+++ b/bash-folders-video-optimizer.sh
@@ -60,11 +60,7 @@ main() {
         case "${1}" in
             -h | --help )       usage; return 0;;
             -- )                shift; break;;
-            * )
-                printf '%s\n' "Unknown option: '${1}'" >&2
-                usage
-                return 1
-                ;;
+            * )                 break;;
         esac
         shift
     done

--- a/bash-folders-video-optimizer.sh
+++ b/bash-folders-video-optimizer.sh
@@ -1,64 +1,81 @@
 #!/usr/bin/env bash
 
-set -e
-
-FOLDER_ORIGIN="$2"
-EXTENSIONS_TO_WATCH=("mkv" "mp4" "avi" "mov")
-MESSAGE_WAITING="optimizing_please_wait"
-
 usage() {
-    [[ -n "${*}" ]] && printf '%s\n' "Error: ${*}" >&2
-
     cat << EOF
-USAGE: ${0##*/} [OPTION] --folder PATH
+USAGE: ${0##*/} [OPTION] PATH
 
 Watches when new videos are added to a folder and optimizes them.
 
 OPTIONS:
     --help          Display this usage message and exit
-    --folder PATH   Folder path where new video will be monitored and optimized
 EOF
-
-    exit 1
 }
 
-start() {
-    inotifywait -m -e create,moved_to --format '%f' "$FOLDER_ORIGIN" | while read -r filename; do
-        extension="${filename##*.}"
-        for ext in "${EXTENSIONS_TO_WATCH[@]}"; do
-            if [[ "$ext" = "$extension" ]]; then
-                if [[ "$filename" != optimized* ]]; then
-                    filename_output="optimized_${filename%.*}.mp4"
-                    touch "$FOLDER_ORIGIN/$MESSAGE_WAITING"
-                    ffmpeg -i "$FOLDER_ORIGIN/$filename" -c:v libx264 -tune stillimage -c:a aac -b:a 192k -pix_fmt yuv420p -nostdin -shortest "/tmp/$filename_output"
-                    mv "/tmp/$filename_output" "$FOLDER_ORIGIN/$filename_output"
-                    rm "$FOLDER_ORIGIN/$MESSAGE_WAITING"
-                fi
-            fi
-        done
-    done
+optimize() {
+    touch -a "${2}"
+    ffmpeg \
+        -i "${1}" \
+        -c:v "libx264" \
+        -tune stillimage \
+        -c:a "aac" \
+        -b:a "192k" \
+        -pix_fmt "yuv420p" \
+        -nostdin \
+        -shortest \
+        "${2}"
 }
 
-isArg=""
+run() {
+    local file extension optimized
+    optimized="${1}/optimized"
 
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-    --help)
-        usage
-        ;;
-    --folder)
-        isArg="1"
-        if [ $# -eq 2 ]; then
-            start
-        else
-            usage "You need to specify the path of the folder to watch."
+    set -e
+
+    mkdir --parents "${optimized}"
+
+    while read -r file; do
+        extension="${file##*.}"
+        [[ "${extension,,}" =~ foo ]] || continue
+
+        printf '%s\n' "Optimizing file '${file}'..."
+
+        if ! optimize "${file}" "${optimized}/${file%.*}.mp4"; then
+            printf '%s\n' "Failed to optimize file: '${file}'" >&2
         fi
-        ;;
-    *)
-    esac
-    shift
-done
+    done < <(inotifywait --monitor --event "create" --event "moved_to" --format '%f' "${1}")
+}
 
-if [[ -z "${isArg}" ]]; then
-    usage "Not enough arguments"
-fi
+main() {
+    local opts
+
+    opts="$(getopt \
+        --options h \
+        --longoptions help \
+        --name "${0##*/}" \
+        -- "${@}" \
+    )"
+
+    eval set -- "${opts}"
+    while true; do
+        case "${1}" in
+            -h | --help )       usage; return 0;;
+            -- )                shift; break;;
+            * )
+                printf '%s\n' "Unknown option: '${1}'" >&2
+                usage
+                return 1
+                ;;
+        esac
+        shift
+    done
+
+    if [[ -z "${1}" ]]; then
+        printf '%s\n' "No folder specified" >&2
+        return 1
+    fi
+
+    mkdir --parents "${1}"
+    run "${1}"
+}
+
+main "${@}"

--- a/bash-folders-video-optimizer.sh
+++ b/bash-folders-video-optimizer.sh
@@ -11,6 +11,12 @@ OPTIONS:
 EOF
 }
 
+require() {
+    command -v "${1}" &>/dev/null && return
+    printf '%s\n' "Missing required application: '${1}'" >&2
+    return 1
+}
+
 optimize() {
     touch -a "${2}"
     ffmpeg \
@@ -66,6 +72,9 @@ main() {
         printf '%s\n' "No folder specified" >&2
         return 1
     fi
+
+    require "inotifywait" || return
+    require "ffmpeg" || return
 
     mkdir --parents "${1}"
     run "${1}"


### PR DESCRIPTION
As per my [commentary on reddit](), this PR contains most of the recommendations in my commentary, as well as some other changes to improve readability, reliability & "simplicity" where possible.

---

## All Scripts

- Removed "unnecessary" comments (subjective, I know)
- Standardized indentation on 4 spaces, rather than a mixture of tabs & spaces
	- Additionally fixed mismatched indentation levels in some blocks
- Removed `Error: $*` message & `exit` statements from `usage()` functions, in favor of explicit `printf` & `return` calls
- Moved all non-function variables/actions to a `main()` function
  - Implied return/exit status for both `main()` & script itself if not explicitly specified
- Ensured default values in both the usage text & code are the same
  - Previously, `bash-folder-battery-hook.sh` showed different defaults than the `LOW_BATTER` & `HIGH_BATTERY` were defined as
- Adjusted argparse to be handled by `util-linux`'s implementation of `getopt`
  - Added single-character flags to compliment the long-options already specified
  - Changed required `FOLDER`/`PATH` to no longer require the `--folder` flag
    - Each script assumes `$1` to be the folder path following argparse
  - Use `shift n` when a value is expected for a parameter, without needing 2 `shift` calls
- Moved `set -e` to a more appropriate location; or removed entirely
- Prefer `printf` over `echo` in all cases
- Error Messages now correctly written to `stderr`, with the `>&2` syntax
- Prefer `[[ ... ]]` or `(( ... ))` expressions over `[ ... ]`/`test` command in _all_ cases

## Battery Hook

- Added an option (`-b|--battery`) to specify a different battery than `BAT0` to be monitored
- Set variables denoting the default High & Low values, as well as battery number
  - Usage now references these directly
- Combined each `run_*` function into a single `run()` function
  - Reads battery status & capacity into variables for easier references
  - Status checks will also run High/Low if battery capacity meets required thresholds
  - Status scripts are called with `$1/${status,,}`; though this probably can just be hardcoded
  - Explicity return success if `set -e` does not force an exit
- Script existence is insured with
  - `mkdir --parents $1` for the parent directory
  - A for-loop to instantiate the scripts & apply execute permissions
  - Leveraging `touch`'s `-a` flag to ensure files exist without [overwriting existing content](https://www.man7.org/linux/man-pages/man1/touch.1.html)
- Reorganized `usage()` to be a little easier to read

## Image to WebP

- Added an option (`-q|--quality`) to specify the compression factor at runtime
  - Note that usage _does not_ reference the `$quality` variable directly, as it cannot be guaranteed that `$quality` will be the default value when `usage()` is called
  - Could be resolved by adding a `default_quality` option; but I felt this was unnecessary
- Added `require()` function, which uses the `command -v` builtin internally to check for commands in `PATH`
  - `which` is an external command _and_ is not standard across all systems/shells; whereas `command` should be builtin and more portable/reliable ([source](https://stackoverflow.com/a/677212/19529668))
  - An error is printed to `stdout` if a required application is missing (`cwebp`, `inotifywait`)
- Replaced `which cwebp` with `require cwebp` function call
- Added `require inotifywait` to ensure this is installed before `run()` is called
- Prefer process subsitition for `while-read` loop for readability
  - Though, this _may_ need to be reverted depending on how `inotifywait` functions
- Use `[[...]]` regular expression (regex) comparison operator, rather than iterating over an array when checking for file extensions
  - Allows for extension to be checked _without_ extracting the extension first, and without iterating over an array
- Prefer an "early skip" approach for extension check, rather than putting all of the code inside an `if` block
- Report to stdout that an image is being optimized, rather than by creating a temporary file
  - This could be logged out to a file if not run interactively as well
  - See my standard [`log() function`](https://github.com/Stewie410/dotfiles/blob/7603472cc44bea0fd9b9211e8406e3e19ff65c9f/scripts/dotfiles/install.sh#L9) for an example solution to print to both stdout/stderr & a logfile
- Prefer long-options for `inotifywait` somewhat better readability
  - The [manual](https://linux.die.net/man/1/inotifywait) specifies that `--event` can be used multiple times; which is easier to understand than `--event 1,2`, in my opinion.  I'm also not seeing `-e 1,2`/`--event 1,2` in the manpage as supported syntax
  - It _could_ also be possible to use the `--exclude` option as an indirect include statement; but I figured this would be hard to understand

## Video Optimizer

- Added `require()` function, which uses the `command -v` builtin internally to check for commands in `PATH`
  - `which` is an external command _and_ is not standard across all systems/shells; whereas `command` should be builtin and more portable/reliable ([source](https://stackoverflow.com/a/677212/19529668))
  - An error is printed to `stdout` if a required application is missing (`ffmpeg`, `inotifywait`)
- Moved `ffmpeg` optimization command to a dedicated function
  - Output file is still generated prior to run, just in case
- Prefer process subsitition for `while-read` loop for readability
  - Though, this _may_ need to be reverted depending on how `inotifywait` functions
- Use `[[...]]` regular expression (regex) comparison operator, rather than iterating over an array when checking for file extensions
  - Allows for extension to be checked _without_ extracting the extension first, and without iterating over an array
- Prefer an "early skip" approach for extension check, rather than putting all of the code inside an `if` block
- Report to stdout that an image is being optimized, rather than by creating a temporary file
  - This could be logged out to a file if not run interactively as well
  - See my standard [`log() function`](https://github.com/Stewie410/dotfiles/blob/7603472cc44bea0fd9b9211e8406e3e19ff65c9f/scripts/dotfiles/install.sh#L9) for an example solution to print to both stdout/stderr & a logfile